### PR TITLE
Exit connectForward if conn error

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -70,12 +70,14 @@ func (f *fluentforwardExporter) stop(context.Context) (err error) {
 func (f *fluentforwardExporter) connectForward() {
 	if err := f.client.Connect(); err != nil {
 		f.settings.Logger.Error(fmt.Sprintf("Failed to connect to the endpoint %s", f.config.Endpoint))
+		return
 	}
 	f.settings.Logger.Info(fmt.Sprintf("Successfull connection to the endpoint %s", f.config.Endpoint))
 
 	if f.config.SharedKey != "" {
 		if err := f.client.Handshake(); err != nil {
-			f.settings.Logger.Error(fmt.Sprintf("Failed to shared key handshake with the endpoint %s", f.config.Endpoint))
+			f.settings.Logger.Error(fmt.Sprintf("Failed shared key handshake with the endpoint %s", f.config.Endpoint))
+			return
 		}
 		f.settings.Logger.Info("Successfull shared key handshake with the endpoint")
 	}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -76,9 +76,8 @@ func TestStartInvalidEndpointErrorLog(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, exporter.client)
-	require.Equal(t, 3, observedLogs.Len())
+	require.Equal(t, 2, observedLogs.Len())
 
 	assert.Equal(t, "Creating the Fluent Forward exporter", observedLogs.All()[0].Message)
 	assert.Equal(t, "Failed to connect to the endpoint invalidEndpoint", observedLogs.All()[1].Message)
-	assert.Equal(t, "Successfull connection to the endpoint invalidEndpoint", observedLogs.All()[2].Message)
 }


### PR DESCRIPTION
If we can't connect, just log the `Failed to connect` error log and exit the function. Same behavior for handshake.