### PR TITLE
Add TCP address resolution validation at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Forward is the protocol used by Fluentd to route message between peers.
 | Property | Default value | Type | Description |
 |---|---|---|---|
 | endpoint.tcp_addr |  | string | **MANDATORY** Target URL to send `Forward` log streams to |
-| endpoint.validate_tcp_resolution | false | bool | Controls whether to validate the tcp address. |
+| endpoint.validate_tcp_resolution | false | bool | Controls whether to validate the tcp address and fail at startup. |
 | connection_timeout | 30s | time.Duration | Maximum amount of time a dial will wait for a connect to complete |
 | tls.insecure | true | bool | If set to **true**, the connexion is not secured with TLS. |
 | tls.insecure_skip_verify | false | bool | Controls whether the exporter verifies the server's certificate chain and host name. If **true**, any certificate is accepted and any host name. This mode is susceptible to man-in-the-middle attacks |
@@ -43,7 +43,8 @@ Example, for `default_labels_enabled` that will add only the `time` attribute in
 ```yaml
 exporters:
   fluentforward:
-    endpoint: a.new.fluentforward.target:24224
+    endpoint:
+      tcp_addr: a.new.fluentforward.target:24224
     connection_timeout: 10s
     require_ack: true
     tag: nginx
@@ -60,7 +61,8 @@ Example with TLS enabled and shared key:
 ```yaml
 exporters:
   fluentforward:
-    endpoint: a.new.fluentforward.target:24224
+    endpoint:
+      tcp_addr: a.new.fluentforward.target:24224
     connection_timeout: 10s
     tls:
       insecure: false
@@ -72,7 +74,8 @@ Example with mutual TLS authentication (mTLS):
 ```yaml
 exporters:
   fluentforward:
-    endpoint: a.new.fluentforward.target:24224
+    endpoint:
+      tcp_addr: a.new.fluentforward.target:24224
     connection_timeout: 10s
     tls:
       insecure: false
@@ -94,7 +97,8 @@ Example usage:
 ```yaml
 exporters:
   fluentforward:
-    endpoint: a.new.fluentforward.target:24224
+    endpoint:
+      tcp_addr: a.new.fluentforward.target:24224
     connection_timeout: 10s
     retry_on_failure:
       enabled: true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Forward is the protocol used by Fluentd to route message between peers.
 
 | Property | Default value | Type | Description |
 |---|---|---|---|
-| endpoint |  | string | **MANDATORY** Target URL to send `Forward` log streams to |
+| endpoint.tcp_addr |  | string | **MANDATORY** Target URL to send `Forward` log streams to |
+| endpoint.validate_tcp_resolution | false | bool | Controls whether to validate the tcp address. |
 | connection_timeout | 30s | time.Duration | Maximum amount of time a dial will wait for a connect to complete |
 | tls.insecure | true | bool | If set to **true**, the connexion is not secured with TLS. |
 | tls.insecure_skip_verify | false | bool | Controls whether the exporter verifies the server's certificate chain and host name. If **true**, any certificate is accepted and any host name. This mode is susceptible to man-in-the-middle attacks |
@@ -31,7 +32,6 @@ Forward is the protocol used by Fluentd to route message between peers.
 | tls.key_file | "" | string | Used for mTLS. Path to the client TLS key to use |
 | shared_key | "" | string | A key string known by the server, used for authorization |
 | require_ack| false | bool | Protocol delivery acknowledgment for log streams : true = at-least-once, false = at-most-once |
-| skip_fail_on_invalid_tcp_endpoint | false | bool | Controls whether to fail if the endpoint is invalid. This is useful for cases where the collector is started before the endpoint becomes available |
 | tag | "tag" | string | Fluentd tag is a string separated by '.'s (e.g. myapp.access), and is used as the directions for Fluentd's internal routing engine |
 | compress_gzip | false | bool | Transparent data compression. You can use this feature to reduce the transferred payload size |
 | default_labels_enabled | true | map[string]bool | If omitted then default labels will be added. If one of the labels is omitted then this label will be added |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Forward is the protocol used by Fluentd to route message between peers.
 | tls.key_file | "" | string | Used for mTLS. Path to the client TLS key to use |
 | shared_key | "" | string | A key string known by the server, used for authorization |
 | require_ack| false | bool | Protocol delivery acknowledgment for log streams : true = at-least-once, false = at-most-once |
+| skip_fail_on_invalid_tcp_endpoint | false | bool | Controls whether to fail if the endpoint is invalid. This is useful for cases where the collector is started before the endpoint becomes available |
 | tag | "tag" | string | Fluentd tag is a string separated by '.'s (e.g. myapp.access), and is used as the directions for Fluentd's internal routing engine |
 | compress_gzip | false | bool | Transparent data compression. You can use this feature to reduce the transferred payload size |
 | default_labels_enabled | true | map[string]bool | If omitted then default labels will be added. If one of the labels is omitted then this label will be added |

--- a/config_test.go
+++ b/config_test.go
@@ -111,6 +111,17 @@ func TestConfigValidate(t *testing.T) {
 			err: fmt.Errorf("exporter has an invalid TCP endpoint: address http://localhost:24224: too many colons in address"),
 		},
 		{
+			desc: "Endpoint is invalid but SkipFailOnInvalidTCPEndpoint is false",
+			cfg: &Config{
+				TCPClientSettings: TCPClientSettings{
+					Endpoint:          "http://localhost:24224",
+					ConnectionTimeout: time.Second * 30,
+				},
+				SkipFailOnInvalidTCPEndpoint: true,
+			},
+			err: nil,
+		},
+		{
 			desc: "Config is valid",
 			cfg: &Config{
 				TCPClientSettings: TCPClientSettings{

--- a/config_test.go
+++ b/config_test.go
@@ -35,7 +35,10 @@ func TestLoadConfigNewExporter(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "allsettings"),
 			expected: &Config{
 				TCPClientSettings: TCPClientSettings{
-					Endpoint:          validEndpoint,
+					Endpoint: Endpoint{
+						TCPAddr:               validEndpoint,
+						ValidateTCPResolution: false,
+					},
 					ConnectionTimeout: time.Second * 30,
 					ClientConfig: configtls.ClientConfig{
 						Insecure:           false,
@@ -97,27 +100,37 @@ func TestConfigValidate(t *testing.T) {
 	}{
 		{
 			desc: "QueueSettings are invalid",
-			cfg:  &Config{QueueConfig: exporterhelper.QueueConfig{QueueSize: -1, Enabled: true}},
-			err:  fmt.Errorf("queue settings has invalid configuration"),
+			cfg: &Config{
+				QueueConfig: exporterhelper.QueueConfig{
+					QueueSize: -1,
+					Enabled:   true,
+				},
+			},
+			err: fmt.Errorf("queue settings has invalid configuration"),
 		},
 		{
 			desc: "Endpoint is invalid",
 			cfg: &Config{
 				TCPClientSettings: TCPClientSettings{
-					Endpoint:          "http://localhost:24224",
+					Endpoint: Endpoint{
+						TCPAddr:               "http://localhost:24224",
+						ValidateTCPResolution: true,
+					},
 					ConnectionTimeout: time.Second * 30,
 				},
 			},
 			err: fmt.Errorf("exporter has an invalid TCP endpoint: address http://localhost:24224: too many colons in address"),
 		},
 		{
-			desc: "Endpoint is invalid but SkipFailOnInvalidTCPEndpoint is false",
+			desc: "Endpoint is invalid but ValidateTCPResolution is false",
 			cfg: &Config{
 				TCPClientSettings: TCPClientSettings{
-					Endpoint:          "http://localhost:24224",
+					Endpoint: Endpoint{
+						TCPAddr:               "http://localhost:24224",
+						ValidateTCPResolution: false,
+					},
 					ConnectionTimeout: time.Second * 30,
 				},
-				SkipFailOnInvalidTCPEndpoint: true,
 			},
 			err: nil,
 		},
@@ -125,7 +138,10 @@ func TestConfigValidate(t *testing.T) {
 			desc: "Config is valid",
 			cfg: &Config{
 				TCPClientSettings: TCPClientSettings{
-					Endpoint:          validEndpoint,
+					Endpoint: Endpoint{
+						TCPAddr:               validEndpoint,
+						ValidateTCPResolution: true,
+					},
 					ConnectionTimeout: time.Second * 30,
 				},
 			},

--- a/config_test.go
+++ b/config_test.go
@@ -122,7 +122,7 @@ func TestConfigValidate(t *testing.T) {
 			err: fmt.Errorf("exporter has an invalid TCP endpoint: address http://localhost:24224: too many colons in address"),
 		},
 		{
-			desc: "Endpoint is invalid but ValidateTCPResolution is false",
+			desc: "Endpoint is invalid with ValidateTCPResolution false throw no error",
 			cfg: &Config{
 				TCPClientSettings: TCPClientSettings{
 					Endpoint: Endpoint{

--- a/exporter.go
+++ b/exporter.go
@@ -41,7 +41,7 @@ func (f *fluentforwardExporter) start(ctx context.Context, host component.Host) 
 		return err
 	}
 	connFactory := &fclient.ConnFactory{
-		Address:   f.config.Endpoint,
+		Address:   f.config.Endpoint.TCPAddr,
 		Timeout:   f.config.ConnectionTimeout,
 		TLSConfig: tlsConfig,
 	}
@@ -69,14 +69,14 @@ func (f *fluentforwardExporter) stop(context.Context) (err error) {
 // connectForward connects to the Fluent Forward endpoint and keep running otel even if the connection is failing
 func (f *fluentforwardExporter) connectForward() {
 	if err := f.client.Connect(); err != nil {
-		f.settings.Logger.Error(fmt.Sprintf("Failed to connect to the endpoint %s", f.config.Endpoint))
+		f.settings.Logger.Error(fmt.Sprintf("Failed to connect to the endpoint %s", f.config.Endpoint.TCPAddr))
 		return
 	}
-	f.settings.Logger.Info(fmt.Sprintf("Successfull connection to the endpoint %s", f.config.Endpoint))
+	f.settings.Logger.Info(fmt.Sprintf("Successfull connection to the endpoint %s", f.config.Endpoint.TCPAddr))
 
 	if f.config.SharedKey != "" {
 		if err := f.client.Handshake(); err != nil {
-			f.settings.Logger.Error(fmt.Sprintf("Failed shared key handshake with the endpoint %s", f.config.Endpoint))
+			f.settings.Logger.Error(fmt.Sprintf("Failed shared key handshake with the endpoint %s", f.config.Endpoint.TCPAddr))
 			return
 		}
 		f.settings.Logger.Info("Successfull shared key handshake with the endpoint")
@@ -134,7 +134,7 @@ func (f *fluentforwardExporter) send(sendMethod sendFunc, entries []fproto.Entry
 		if errr := f.client.Disconnect(); errr != nil {
 			return errr
 		}
-		f.settings.Logger.Warn(fmt.Sprintf("Failed to send data to the endpoint %s, trying to reconnect", f.config.Endpoint))
+		f.settings.Logger.Warn(fmt.Sprintf("Failed to send data to the endpoint %s, trying to reconnect", f.config.Endpoint.TCPAddr))
 		f.connectForward()
 		err = sendMethod(f.config.Tag, entries)
 		if err != nil {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -18,8 +18,7 @@ func TestNewExporter(t *testing.T) {
 	config := &Config{
 		TCPClientSettings: TCPClientSettings{
 			Endpoint: Endpoint{
-				TCPAddr:               validEndpoint,
-				ValidateTCPResolution: true,
+				TCPAddr: validEndpoint,
 			},
 			ConnectionTimeout: time.Second * 30,
 		},
@@ -40,8 +39,7 @@ func TestStart(t *testing.T) {
 	config := &Config{
 		TCPClientSettings: TCPClientSettings{
 			Endpoint: Endpoint{
-				TCPAddr:               validEndpoint,
-				ValidateTCPResolution: true,
+				TCPAddr: validEndpoint,
 			},
 			ConnectionTimeout: time.Second * 30,
 		},

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -17,7 +17,10 @@ import (
 func TestNewExporter(t *testing.T) {
 	config := &Config{
 		TCPClientSettings: TCPClientSettings{
-			Endpoint:          validEndpoint,
+			Endpoint: Endpoint{
+				TCPAddr:               validEndpoint,
+				ValidateTCPResolution: true,
+			},
 			ConnectionTimeout: time.Second * 30,
 		},
 	}
@@ -36,7 +39,10 @@ func TestNewExporter(t *testing.T) {
 func TestStart(t *testing.T) {
 	config := &Config{
 		TCPClientSettings: TCPClientSettings{
-			Endpoint:          validEndpoint,
+			Endpoint: Endpoint{
+				TCPAddr:               validEndpoint,
+				ValidateTCPResolution: true,
+			},
 			ConnectionTimeout: time.Second * 30,
 		},
 	}
@@ -61,7 +67,10 @@ func TestStartInvalidEndpointErrorLog(t *testing.T) {
 
 	config := &Config{
 		TCPClientSettings: TCPClientSettings{
-			Endpoint:          "invalidEndpoint",
+			Endpoint: Endpoint{
+				TCPAddr:               "invalidEndpoint",
+				ValidateTCPResolution: true,
+			},
 			ConnectionTimeout: time.Second * 30,
 		},
 	}

--- a/factory.go
+++ b/factory.go
@@ -31,7 +31,10 @@ func NewFactory() exporter.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		TCPClientSettings: TCPClientSettings{
-			Endpoint:          "localhost:24224",
+			Endpoint: Endpoint{
+				TCPAddr:               "localhost:24224",
+				ValidateTCPResolution: false,
+			},
 			ConnectionTimeout: time.Second * 30,
 			ClientConfig: configtls.ClientConfig{
 				Insecure:           true,

--- a/factory.go
+++ b/factory.go
@@ -62,7 +62,7 @@ func createLogsExporter(ctx context.Context, set exporter.Settings, config compo
 	exporterConfig := config.(*Config)
 	exp := newExporter(exporterConfig, set.TelemetrySettings)
 
-	return exporterhelper.NewLogsExporter(
+	return exporterhelper.NewLogs(
 		ctx,
 		set,
 		config,

--- a/factory_test.go
+++ b/factory_test.go
@@ -31,8 +31,7 @@ func TestNewExporterMinimalConfig(t *testing.T) {
 		config := &Config{
 			TCPClientSettings: TCPClientSettings{
 				Endpoint: Endpoint{
-					TCPAddr:               validEndpoint,
-					ValidateTCPResolution: true,
+					TCPAddr: validEndpoint,
 				},
 				ConnectionTimeout: time.Second * 30,
 			},
@@ -89,8 +88,7 @@ func TestStartAlwaysReturnsNil(t *testing.T) {
 	config := &Config{
 		TCPClientSettings: TCPClientSettings{
 			Endpoint: Endpoint{
-				TCPAddr:               validEndpoint,
-				ValidateTCPResolution: true,
+				TCPAddr: validEndpoint,
 			},
 			ConnectionTimeout: time.Second * 30,
 		},
@@ -104,8 +102,7 @@ func TestStopAlwaysReturnsNil(t *testing.T) {
 	config := &Config{
 		TCPClientSettings: TCPClientSettings{
 			Endpoint: Endpoint{
-				TCPAddr:               validEndpoint,
-				ValidateTCPResolution: true,
+				TCPAddr: validEndpoint,
 			},
 			ConnectionTimeout: time.Second * 30,
 		},

--- a/factory_test.go
+++ b/factory_test.go
@@ -30,7 +30,10 @@ func TestNewExporterMinimalConfig(t *testing.T) {
 	t.Run("with valid config", func(t *testing.T) {
 		config := &Config{
 			TCPClientSettings: TCPClientSettings{
-				Endpoint:          validEndpoint,
+				Endpoint: Endpoint{
+					TCPAddr:               validEndpoint,
+					ValidateTCPResolution: true,
+				},
 				ConnectionTimeout: time.Second * 30,
 			},
 		}
@@ -43,7 +46,10 @@ func TestNewExporterFullConfig(t *testing.T) {
 	t.Run("with valid config", func(t *testing.T) {
 		config := &Config{
 			TCPClientSettings: TCPClientSettings{
-				Endpoint:          validEndpoint,
+				Endpoint: Endpoint{
+					TCPAddr:               validEndpoint,
+					ValidateTCPResolution: true,
+				},
 				ConnectionTimeout: time.Second * 30,
 				ClientConfig: configtls.ClientConfig{
 					Insecure:           true,
@@ -82,7 +88,10 @@ func TestNewExporterFullConfig(t *testing.T) {
 func TestStartAlwaysReturnsNil(t *testing.T) {
 	config := &Config{
 		TCPClientSettings: TCPClientSettings{
-			Endpoint:          validEndpoint,
+			Endpoint: Endpoint{
+				TCPAddr:               validEndpoint,
+				ValidateTCPResolution: true,
+			},
 			ConnectionTimeout: time.Second * 30,
 		},
 	}
@@ -94,7 +103,10 @@ func TestStartAlwaysReturnsNil(t *testing.T) {
 func TestStopAlwaysReturnsNil(t *testing.T) {
 	config := &Config{
 		TCPClientSettings: TCPClientSettings{
-			Endpoint:          validEndpoint,
+			Endpoint: Endpoint{
+				TCPAddr:               validEndpoint,
+				ValidateTCPResolution: true,
+			},
 			ConnectionTimeout: time.Second * 30,
 		},
 	}

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -1,7 +1,9 @@
 fluentforward:
   endpoint: "localhost:24224"
 fluentforward/allsettings:
-  endpoint: "localhost:24224"
+  endpoint: 
+    tcp_addr: "localhost:24224"
+    validate_tcp_resolution: false
   connection_timeout: 30s
   tls:
     insecure: false

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -1,8 +1,9 @@
 fluentforward:
-  endpoint: "localhost:24224"
+  endpoint:
+    tcp_addr: localhost:24224
 fluentforward/allsettings:
-  endpoint: 
-    tcp_addr: "localhost:24224"
+  endpoint:
+    tcp_addr: localhost:24224
     validate_tcp_resolution: false
   connection_timeout: 30s
   tls:


### PR DESCRIPTION
Mainly developed by @csatib02 

Breaking change for this exporter as it is needed to switch configuration.

From:
```
exporters:
  fluentforward:
    endpoint: localhost:24224
```

To:
```
exporters:
  fluentforward:
    endpoint: 
      tcp_addr: localhost:24224
```