### PR TITLE
Add all attributes in the exported log record

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Forward is the protocol used by Fluentd to route message between peers.
 
 See the default values in the method `createDefaultConfig()` in [factory.go](factory.go) file.
 
-Example, for `default_labels_enabled` that will add only the `time` attribute in the log record:
+Example, for `default_labels_enabled` that will add only the `timestamp` attribute in the log record:
 
 ```yaml
 exporters:
@@ -50,11 +50,12 @@ exporters:
     tag: nginx
     compress_gzip: true
     default_labels_enabled:
-      time: true
-      exporter: false
-      job: false
-      instance: false
+      timestamp: true
+      level: false
+      message: false
 ```
+
+But a best practice is to have at least `timestamp`, `level` and `message` in the exported log record to a Fluent endpoint.
 
 Example with TLS enabled and shared key:
 

--- a/config_test.go
+++ b/config_test.go
@@ -55,10 +55,9 @@ func TestLoadConfigNewExporter(t *testing.T) {
 				Tag:          "nginx",
 				CompressGzip: true,
 				DefaultLabelsEnabled: map[string]bool{
-					"time":     true,
-					"exporter": false,
-					"job":      false,
-					"instance": false,
+					"timestamp": true,
+					"level":     true,
+					"message":   true,
 				},
 				BackOffConfig: configretry.BackOffConfig{
 					Enabled:             true,

--- a/factory.go
+++ b/factory.go
@@ -51,10 +51,9 @@ func createDefaultConfig() component.Config {
 		Tag:          "tag",
 		CompressGzip: false,
 		DefaultLabelsEnabled: map[string]bool{
-			"time":     true,
-			"exporter": true,
-			"job":      true,
-			"instance": true,
+			"timestamp": true,
+			"level":     true,
+			"message":   true,
 		},
 		BackOffConfig: configretry.NewDefaultBackOffConfig(),
 		QueueConfig:   exporterhelper.NewDefaultQueueConfig(),

--- a/factory_test.go
+++ b/factory_test.go
@@ -60,10 +60,9 @@ func TestNewExporterFullConfig(t *testing.T) {
 			Tag:          "tag",
 			CompressGzip: true,
 			DefaultLabelsEnabled: map[string]bool{
-				"time":     true,
-				"exporter": true,
-				"job":      true,
-				"instance": true,
+				"timestamp": true,
+				"level":     true,
+				"message":   true,
 			},
 			BackOffConfig: configretry.BackOffConfig{
 				Enabled:             true,

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -17,10 +17,9 @@ fluentforward/allsettings:
   tag: nginx
   compress_gzip: true
   default_labels_enabled:
-    time: true
-    exporter: false
-    job: false
-    instance: false
+    timestamp: true
+    level: true
+    message: true
   sending_queue:
     enabled: true
     num_consumers: 2


### PR DESCRIPTION
This change to add by default all otel attributes into the log record. And modify the `default_labels_enabled` property behavior.

### Breaking change 1

Add by default all otel attributes into the log record.

If some attributes are not wanted, you must use the [processor/attributesprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/attributesprocessor), example to remove the `hostname` attribute

```yaml
processors:
  attributes:
    actions:
      - key: hostname
        action: delete
```

### Breaking change 2

The `default_labels_enabled` property act upon standard fields required by a Fluent endpoint and the OpenTelemetry [logs/data-model](https://opentelemetry.io/docs/specs/otel/logs/data-model/#log-and-event-record-definition) definition.

This property allows to include or exclude the 3 fields `timestamp`, `level` and `message`.

Best practice, keep them all. To disable one, set to false.

```yaml
  default_labels_enabled:
    timestamp: true
    level: true
    message: true
```

### Breaking change 3

In the exported log record, the field `severity` is now labeled `level` as it is usual to see level in ElasticSearch usage.