### PR TITLE
Fix #16 Otel pLogRecord time -> Fluent timestamp

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -97,8 +97,10 @@ func (f *fluentforwardExporter) pushLogData(ctx context.Context, ld plog.Logs) e
 			for k := 0; k < logs.Len(); k++ {
 				log := logs.At(k)
 				entry := fproto.EntryExt{
-					Timestamp: fproto.EventTimeNow(),
-					Record:    f.convertLogToMap(log),
+					Timestamp: fproto.EventTime{
+						Time: log.Timestamp().AsTime(),
+					},
+					Record: f.convertLogToMap(log),
 				}
 				entries = append(entries, entry)
 			}


### PR DESCRIPTION
The OpenTelemetry log record timestamp must be used as the fluent log record timestamp.

This is a breaking change.